### PR TITLE
Configure `SWXSOC_MISSION` Env Var on init of Instrument Package

### DIFF
--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -25,7 +25,7 @@ jobs:
         
     - name: Run Lambda Docker Container
       run: |
-        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e LAMBDA_ENVIRONMENT=DEVELOPMENT -e processing_function:latest
+        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e LAMBDA_ENVIRONMENT=DEVELOPMENT processing_function:latest
         container_id=$(docker ps -qf "ancestor=processing_function:latest")
         echo "Container ID: $container_id"
 

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -25,7 +25,7 @@ jobs:
         
     - name: Run Lambda Docker Container
       run: |
-        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e SWXSOC_MISSION=padre processing_function:latest
+        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e LAMBDA_ENVIRONMENT=DEVELOPMENT -e processing_function:latest
         container_id=$(docker ps -qf "ancestor=processing_function:latest")
         echo "Container ID: $container_id"
 

--- a/.github/workflows/test_in_container.yml
+++ b/.github/workflows/test_in_container.yml
@@ -24,6 +24,6 @@ jobs:
       env:
         PLATFORM: 'docker'
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       env: 
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_in_container.yml
+++ b/.github/workflows/test_in_container.yml
@@ -23,7 +23,7 @@ jobs:
       run: pytest --pyargs padre_meddea --cov padre_meddea
       env:
         PLATFORM: 'docker'
-        SWXSOC_MISSION: padre
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
-        env: CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      env: 
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -38,7 +38,6 @@ jobs:
       env:
         #
         PLATFORM: ${{ matrix.platform }}
-        SWXSOC_MISSION: padre
         #
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,5 +39,8 @@ jobs:
         #
         PLATFORM: ${{ matrix.platform }}
         #
-    - name: Upload coverage reports to Codecov with GitHub Action
-      uses: codecov/codecov-action@v3
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3	
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,7 +40,7 @@ jobs:
         PLATFORM: ${{ matrix.platform }}
         #
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3	
+      uses: codecov/codecov-action@v4	
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/padre_meddea/__init__.py
+++ b/padre_meddea/__init__.py
@@ -1,4 +1,5 @@
 # see license/LICENSE.rst
+import os
 from pathlib import Path
 
 try:
@@ -8,7 +9,15 @@ except ImportError:
     __version__ = "unknown version"
     version_tuple = (0, 0, "unknown version")
 
-from swxsoc import config as swxsoc_config, log as swxsoc_log, print_config
+# Get SWXSOC_MISSIONS environment variable if it exists or use default for mission
+SWXSOC_MISSION = os.getenv("SWXSOC_MISSION", "padre")
+os.environ["SWXSOC_MISSION"] = SWXSOC_MISSION
+
+from swxsoc import (  # noqa: E402
+    config as swxsoc_config,
+    log as swxsoc_log,
+    print_config,
+)
 
 # Load user configuration
 config = swxsoc_config


### PR DESCRIPTION
In this PR, we configure the environmental variable `SWXSOC_MISSION` on initialization or import of the instrument package so that the `swxsoc` package can use the right mission configuration (in this case `padre`) without the need for the user to set-up a custom configuration or set the environmental variable themselves. 

It doesn't overwrite if the `SWXSOC_MISSION` environmental variable already exists, so that users can still change the configured mission if they'd like within their development environment. 

`swxsoc` mission configuration file maintained by us for the missions we support: https://github.com/swxsoc/swxsoc/blob/main/swxsoc/data/config.yml

More info on how to customize the `swxsoc` core package configuration can be found here: https://swxsoc.readthedocs.io/en/latest/user-guide/customization.html


Other fixes in this PR:
- Fixes a broken workflow which runs tests within the container
- Also updates a workflow so that it processes the file to the correct directory within the container `tmp` 
- Updates Codecov report