### PR TITLE
Updates Numpy Version & Fixes Broken Test

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,7 +34,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -e '.[test]'
     - name: Run tests
-      run: pytest --pyargs padre_meddea --cov padre_meddea
+      run: pytest --pyargs padre_meddea --cov padre_meddea no:warnings
       env:
         #
         PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,7 +40,6 @@ jobs:
       env:
         #
         PLATFORM: ${{ matrix.platform }}
-        PYTHONWARNINGS: "ignore"
         #
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4	

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,11 +33,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -e '.[test]'
+
+
     - name: Run tests
-      run: pytest --pyargs padre_meddea --cov padre_meddea no:warnings
+      run: pytest --pyargs padre_meddea --cov padre_meddea
       env:
         #
         PLATFORM: ${{ matrix.platform }}
+        PYTHONWARNINGS: "ignore"
         #
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4	

--- a/padre_meddea/util/util.py
+++ b/padre_meddea/util/util.py
@@ -126,10 +126,10 @@ def str_to_fits_keyword(keyword: str) -> str:
 def is_consecutive(arr: np.array) -> bool:
     """Return True if the packet sequence numbers are all consecutive integers, has no missing numbers."""
     MAX_SEQCOUNT = 2**14 - 1  # 16383
-    
+
     # Ensure arr is at least 1D
     arr = np.atleast_1d(arr)
-    
+
     # check if seqcount has wrapped around
     indices = np.where(arr == MAX_SEQCOUNT)
     if len(indices[0]) == 0:  # no wrap

--- a/padre_meddea/util/util.py
+++ b/padre_meddea/util/util.py
@@ -126,6 +126,10 @@ def str_to_fits_keyword(keyword: str) -> str:
 def is_consecutive(arr: np.array) -> bool:
     """Return True if the packet sequence numbers are all consecutive integers, has no missing numbers."""
     MAX_SEQCOUNT = 2**14 - 1  # 16383
+    
+    # Ensure arr is at least 1D
+    arr = np.atleast_1d(arr)
+    
     # check if seqcount has wrapped around
     indices = np.where(arr == MAX_SEQCOUNT)
     if len(indices[0]) == 0:  # no wrap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   'astropy==6.1.*',
-  'numpy==2.2.*',
+  'numpy==1.26.*',
   'sunpy==6.0.*',
   'roentgen',
   'specutils==1.15.*',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   'astropy==6.1.*',
-  'numpy==1.26.*',
+  'numpy==2.2.*',
   'sunpy==6.0.*',
   'roentgen',
   'specutils==1.15.*',


### PR DESCRIPTION
This PR updates NumPy to the latest version, which fixes a broken test on Windows for the Python 3.13. It also fixes a ValueError in is_consecutive caused by calling .nonzero() on a 0D array when using np.where(). The issue occurred when arr was unexpectedly scalar or empty in the newer version of numpy.