### PR TITLE
Modify calibrated filenames to match our new folder structure

### DIFF
--- a/padre_meddea/calibration/calibration.py
+++ b/padre_meddea/calibration/calibration.py
@@ -78,7 +78,7 @@ def process_file(filename: Path, overwrite=False) -> list:
             event_list.remove_column("time")
 
             # Get FITS Primary Header Template
-            primary_hdr = get_primary_header(file_path, "l1", "photon")
+            primary_hdr = get_primary_header(file_path, "l0", "photon")
 
             for this_keyword in ["DATE-BEG", "DATE-END", "DATE-AVG"]:
                 primary_hdr[this_keyword] = (
@@ -90,7 +90,7 @@ def process_file(filename: Path, overwrite=False) -> list:
             path = create_science_filename(
                 "meddea",
                 time=primary_hdr["DATE-BEG"],
-                level="l1",
+                level="l0",
                 descriptor="eventlist",
                 test=True,
                 version="0.1.0",
@@ -125,7 +125,7 @@ def process_file(filename: Path, overwrite=False) -> list:
             hk_table = Table(hk_data)
 
             # Get FITS Primary Header Template
-            primary_hdr = get_primary_header(file_path, "l1", "housekeeping")
+            primary_hdr = get_primary_header(file_path, "l0", "housekeeping")
 
             date_beg = calc_time(hk_data["timestamp"][0])
             primary_hdr["DATEREF"] = (date_beg.fits, get_comment("DATEREF"))
@@ -149,7 +149,7 @@ def process_file(filename: Path, overwrite=False) -> list:
             path = create_science_filename(
                 "meddea",
                 time=date_beg,
-                level="l1",
+                level="l0",
                 descriptor="hk",
                 test=True,
                 version="0.1.0",
@@ -212,7 +212,7 @@ def process_file(filename: Path, overwrite=False) -> list:
             # TODO check that asic_nums and channel_nums do not change
 
             # Get FITS Primary Header Template
-            primary_hdr = get_primary_header(file_path, "l1", "spectrum")
+            primary_hdr = get_primary_header(file_path, "l0", "spectrum")
 
             dates = {
                 "DATE-BEG": ts.time[0].fits,
@@ -229,7 +229,7 @@ def process_file(filename: Path, overwrite=False) -> list:
             path = create_science_filename(
                 "meddea",
                 time=dates["DATE-BEG"],
-                level="l1",
+                level="l0",
                 descriptor="spec",
                 test=True,
                 version="0.1.0",

--- a/padre_meddea/io/file_tools.py
+++ b/padre_meddea/io/file_tools.py
@@ -259,9 +259,11 @@ def parse_ph_packets(filename: Path):
     pkt_list["inttime"] = ph_data["INTEGRATION_TIME"]
     pkt_list["flags"] = ph_data["FLAGS"]
     # parse flag field into their own
-    pkt_list["decim_lvl"], pkt_list["drop_cnt"], pkt_list["int_time_flag"] = (
-        util.parse_ph_flags(pkt_list["flags"])
-    )
+    (
+        pkt_list["decim_lvl"],
+        pkt_list["drop_cnt"],
+        pkt_list["int_time_flag"],
+    ) = util.parse_ph_flags(pkt_list["flags"])
     pkt_list.meta.update({"ORIGFILE": f"{filename.name}"})
 
     # determine the total amount of hits in all photon packets

--- a/padre_meddea/tests/test_calibration.py
+++ b/padre_meddea/tests/test_calibration.py
@@ -18,3 +18,6 @@ def test_process_file_test_file():
     # assert f[1].data["atod"][0] == 1336
     # assert len(f[1].data["atod"]) == 760
     Path(files[0]).unlink
+
+    # Assert filename is correct
+    assert files[0] == "padre_meddea_l0test_eventlist_20240916T122901_v0.1.0.fits"


### PR DESCRIPTION
Changes the level on the calibrated filenames to match our new folder structure for PADRE. Also improves the calibration test to include a filename check and performs lintings.

E.I.
```
Padre/meddea/raw/year/month/day/
Padre/meddea/l0/spectrum/year/month
Padre/meddea/l0/eventlist/year/month
Padre/meddea/l0/housekeeping/year/month
Padre/meddea/l1/spectrum/year/month
Padre/meddea/l1/eventlist/year/month
Padre/meddea/l1/housekeeping/year/month
```