### PR TITLE
Calibrate temperatures before sending to timeseries

### DIFF
--- a/padre_meddea/io/aws_db.py
+++ b/padre_meddea/io/aws_db.py
@@ -7,6 +7,7 @@ from swxsoc.util.util import record_timeseries, create_annotation
 
 from padre_meddea import log
 import padre_meddea.util.util as util
+from padre_meddea.housekeeping.calibration import get_calibration_func
 
 
 def record_spectra(pkt_ts, spectra, ids):
@@ -39,8 +40,25 @@ def record_photons(pkt_list, event_list):
     create_annotation(pkt_list.time[0], f"{pkt_list.meta['ORIGFILE']}", ["meta"])
 
 
-def record_housekeeping(hk_ts):
+def record_housekeeping(hk_ts: TimeSeries):
     """Send the housekeeping time series to AWS."""
+    colnames_to_remove = [
+        "CCSDS_APID"
+        "CCSDS_VERSION_NUMBER",
+        "CCSDS_PACKET_TYPE",
+        "CCSDS_SECONDARY_FLAG",
+        "CCSDS_SEQUENCE_FLAG",
+        "CCSDS_SEQUENCE_COUNT",
+        "CCSDS_PACKET_LENGTH",
+        "timestamp",
+        "CHECKSUM"]
+    hk_ts.remove_columns(colnames_to_remove)
+    # calibrate hard to calibrate columns before sending
+    colnames_to_calibrate = ["fp_temp", "hvps_temp", "dib_temp"]
+    for this_col in colnames_to_calibrate:
+        f = get_calibration_func(this_col)
+        hk_ts[f'cal_{this_col}'] = f(hk_ts[this_col])
+
     record_timeseries(hk_ts, "housekeeping", "meddea")
     create_annotation(hk_ts.time[0], f"{hk_ts.meta['ORIGFILE']}", ["meta"])
 


### PR DESCRIPTION
Our temperatures are hard to calibrate on the fly in grafana so calibrate them before sending to the timeseries database.