### PR TITLE
Add File Size Validation

### DIFF
--- a/padre_meddea/calibration/calibration.py
+++ b/padre_meddea/calibration/calibration.py
@@ -48,7 +48,7 @@ def process_file(filename: Path, overwrite=False) -> list:
         # Before we process, validate the file with CCSDS
         custom_validators = [
             validation.validate_packet_checksums,
-            lambda f: validation.validate_file_size(f, size_limit=10000000),  # 10 MB
+            lambda f: validation.validate_file_size(f, size_limit=10500000),  # 10 MB
         ]
         validation_findings = validation.validate(
             file_path,

--- a/padre_meddea/calibration/calibration.py
+++ b/padre_meddea/calibration/calibration.py
@@ -46,7 +46,10 @@ def process_file(filename: Path, overwrite=False) -> list:
 
     if file_path.suffix.lower() in [".bin", ".dat"]:  # raw file
         # Before we process, validate the file with CCSDS
-        custom_validators = [validation.validate_packet_checksums]
+        custom_validators = [
+            validation.validate_packet_checksums,
+            lambda f: validation.validate_file_size(f, size_limit=10000000),  # 10 MB
+        ]
         validation_findings = validation.validate(
             file_path,
             valid_apids=list(padre_meddea.APID.values()),

--- a/padre_meddea/tests/test_util_validation.py
+++ b/padre_meddea/tests/test_util_validation.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import padre_meddea
 from padre_meddea.util import validation
 
@@ -6,6 +7,44 @@ def test_validate_packet_checksums():
     test_file = padre_meddea._test_files_directory / "apid160_4packets.bin"
     warnings = validation.validate_packet_checksums(test_file)
     assert len(warnings) == 0
+
+
+def test_validate_file_size_within_limit(tmp_path, monkeypatch):
+    """Test that a file within size limits produces no warnings."""
+    # Create a small test file
+    test_file = tmp_path / "small_file.bin"
+    test_file.write_bytes(b"small content")
+
+    warnings = validation.validate_file_size(test_file, size_limit=1024)
+    assert len(warnings) == 0
+
+
+def test_validate_file_size_exceeds_limit(tmp_path, monkeypatch):
+    """Test that a file exceeding size limits produces a warning."""
+    # Create a test file
+    test_file = tmp_path / "large_file.bin"
+    test_file.write_bytes(b"content")
+
+    # Create a simple mock stat result
+    class MockStat:
+        st_size = 1024 * 1024 * 100  # 100 MB
+
+    # Save original stat method
+    original_stat = Path.stat
+
+    # Define wrapper that returns mock for our test file
+    def mock_stat(self):
+        if self == test_file:
+            return MockStat()
+        return original_stat(self)
+
+    # Patch at the class level
+    monkeypatch.setattr(Path, "stat", mock_stat)
+
+    warnings = validation.validate_file_size(test_file, size_limit=1024)
+    assert len(warnings) == 1
+    assert "FileSizeWarning" in warnings[0]
+    assert "exceeds expected size" in warnings[0]
 
 
 def test_validate():

--- a/padre_meddea/util/validation.py
+++ b/padre_meddea/util/validation.py
@@ -2,19 +2,20 @@
 This module contains utilities for file and packet validation.
 """
 
+from pathlib import Path
 from typing import List
 
 import numpy as np
 from ccsdspy import utils
 
 
-def validate_packet_checksums(file) -> List[str]:
+def validate_packet_checksums(file: Path) -> List[str]:
     """
     Custom Validation Function to check that all packets have contents that match their checksums. This is achieved be a rolling XOR of the packet contents. If the final XOR value is not 0, a warning is issued.
 
     Parameters
     ----------
-    file: `str | BytesIO`
+    file: `Path`
         A file path (str) or file-like object with a `.read()` method.
 
     Returns
@@ -33,6 +34,30 @@ def validate_packet_checksums(file) -> List[str]:
             validation_warnings.append(
                 f"ChecksumWarning: Packet {i} has a checksum error."
             )
+    return validation_warnings
+
+
+def validate_file_size(file: Path, size_limit: int) -> List[str]:
+    """
+    Custom Validation Function to check that the file size is no larger than the expected size.
+
+    Parameters
+    ----------
+    file: `Path`
+        A file path (str) or file-like object with a `.read()` method.
+    expected_size: `int`
+        The expected maximum size of the file in bytes.
+
+    Returns
+    -------
+    List of strings, each in the format "WarningType: message", describing potential validation issues. Returns an empty list if no warnings are issued.
+    """
+    validation_warnings = []
+    actual_size = Path(file).stat().st_size
+    if actual_size > size_limit:
+        validation_warnings.append(
+            f"FileSizeWarning: File size {actual_size} bytes exceeds expected size of {size_limit} bytes."
+        )
     return validation_warnings
 
 


### PR DESCRIPTION
This adds validation code to make sure files are under 10MB. For files processed greater than 10MB in size, a warning is logged with the filename and the errant size. 

resolves #98 