### PR TITLE
Update Calibration Workflow

### DIFF
--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -9,6 +9,7 @@ jobs:
   test-and-upload:
     permissions:
         pull-requests: write
+        issues: write
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -1,12 +1,6 @@
 name: Test Lambda Function Locally and Upload Artifacts
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [pull_request_target]
 
 jobs:
   test-and-upload:
@@ -17,11 +11,6 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
-    - name: Checkout Processing Repo
-      uses: actions/checkout@v4
-      with:
-        repository: swxsoc/sdc_aws_processing_lambda
-        path: sdc_aws_processing_lambda
     - name: Build Lambda Docker Image
       run: |
         # Define the repository and branch dynamically
@@ -32,8 +21,8 @@ jobs:
         echo "Branch URL: $BRANCH_URL"
     
         # Clone the Lambda function repository
-        # git clone https://github.com/swxsoc/sdc_aws_processing_lambda.git ../sdc_aws_processing_lambda
-        cd sdc_aws_processing_lambda/lambda_function
+        git clone https://github.com/HERMES-SOC/sdc_aws_processing_lambda.git ../sdc_aws_processing_lambda
+        cd ../sdc_aws_processing_lambda/lambda_function
     
         # Define mission name & instrument name from the repository name
         PACKAGE_NAME=$(basename -s .git $REPO_URL)

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: swxsoc/sdc_aws_processing_lambda
-        path: ../sdc_aws_processing_lambda
+        path: sdc_aws_processing_lambda
     - name: Build Lambda Docker Image
       run: |
         # Define the repository and branch dynamically
@@ -33,7 +33,7 @@ jobs:
     
         # Clone the Lambda function repository
         # git clone https://github.com/swxsoc/sdc_aws_processing_lambda.git ../sdc_aws_processing_lambda
-        cd ../sdc_aws_processing_lambda/lambda_function
+        cd sdc_aws_processing_lambda/lambda_function
     
         # Define mission name & instrument name from the repository name
         PACKAGE_NAME=$(basename -s .git $REPO_URL)

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -21,7 +21,7 @@ jobs:
         echo "Branch URL: $BRANCH_URL"
     
         # Clone the Lambda function repository
-        git clone https://github.com/HERMES-SOC/sdc_aws_processing_lambda.git ../sdc_aws_processing_lambda
+        git clone https://github.com/swxsoc/sdc_aws_processing_lambda.git ../sdc_aws_processing_lambda
         cd ../sdc_aws_processing_lambda/lambda_function
     
         # Define mission name & instrument name from the repository name

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -9,6 +9,7 @@ jobs:
   test-and-upload:
     permissions:
         pull-requests: write
+        issues: write
     runs-on: ubuntu-latest
 
     steps:
@@ -139,7 +140,15 @@ jobs:
     
     - name: Comment PR
       if: steps.test-lambda.outputs.test_success == 'true' && github.event_name == 'pull_request'
-      uses: thollander/actions-comment-pull-request@v3
+      uses: actions/github-script@v8
+      env:
+        ARTIFACT_ID: ${{ steps.artifact-upload-step.outputs.artifact-id }}
       with:
-        message: |
-          The processed files are available as an artifact: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}
+        script: |
+          const message = `The processed files are available as an artifact: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/artifacts/${process.env.ARTIFACT_ID}`;
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            body: message,
+          });

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -1,6 +1,12 @@
 name: Test Lambda Function Locally and Upload Artifacts
 
-on: [pull_request_target]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test-and-upload:

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -11,6 +11,11 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
+    - name: Checkout Processing Repo
+      uses: actions/checkout@v4
+      with:
+        repository: swxsoc/sdc_aws_processing_lambda
+        path: ../sdc_aws_processing_lambda
     - name: Build Lambda Docker Image
       run: |
         # Define the repository and branch dynamically
@@ -21,7 +26,7 @@ jobs:
         echo "Branch URL: $BRANCH_URL"
     
         # Clone the Lambda function repository
-        git clone https://github.com/swxsoc/sdc_aws_processing_lambda.git ../sdc_aws_processing_lambda
+        # git clone https://github.com/swxsoc/sdc_aws_processing_lambda.git ../sdc_aws_processing_lambda
         cd ../sdc_aws_processing_lambda/lambda_function
     
         # Define mission name & instrument name from the repository name

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -9,7 +9,6 @@ jobs:
   test-and-upload:
     permissions:
         pull-requests: write
-        issues: write
     runs-on: ubuntu-latest
 
     steps:
@@ -140,15 +139,7 @@ jobs:
     
     - name: Comment PR
       if: steps.test-lambda.outputs.test_success == 'true' && github.event_name == 'pull_request'
-      uses: actions/github-script@v8
-      env:
-        ARTIFACT_ID: ${{ steps.artifact-upload-step.outputs.artifact-id }}
+      uses: andyghc/actions-comment-pull-request@v3
       with:
-        script: |
-          const message = `The processed files are available as an artifact: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/artifacts/${process.env.ARTIFACT_ID}`;
-          await github.rest.issues.createComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-            body: message,
-          });
+        message: |
+          The processed files are available as an artifact: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -1,6 +1,9 @@
 name: Test Lambda Function Locally and Upload Artifacts
 
-on: [pull_request_target]
+on:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test-and-upload:
@@ -11,6 +14,7 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
+
     - name: Build Lambda Docker Image
       run: |
         # Define the repository and branch dynamically
@@ -21,7 +25,7 @@ jobs:
         echo "Branch URL: $BRANCH_URL"
     
         # Clone the Lambda function repository
-        git clone https://github.com/HERMES-SOC/sdc_aws_processing_lambda.git ../sdc_aws_processing_lambda
+        git clone https://github.com/swxsoc/sdc_aws_processing_lambda.git ../sdc_aws_processing_lambda
         cd ../sdc_aws_processing_lambda/lambda_function
     
         # Define mission name & instrument name from the repository name
@@ -128,7 +132,7 @@ jobs:
       run: echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}"
     
     - name: Comment PR
-      if: steps.test-lambda.outputs.test_success == 'true' && github.event_name == 'pull_request_target'
+      if: steps.test-lambda.outputs.test_success == 'true' && github.event_name == 'pull_request'
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -139,7 +139,7 @@ jobs:
     
     - name: Comment PR
       if: steps.test-lambda.outputs.test_success == 'true' && github.event_name == 'pull_request'
-      uses: thollander/actions-comment-pull-request@v2
+      uses: thollander/actions-comment-pull-request@v3
       with:
         message: |
           The processed files are available as an artifact: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -49,6 +49,12 @@ jobs:
         # Remove any previous entries for instrument package and add the new branch URL as the first entry
         sed -i "/${PACKAGE_NAME}/d" $REQUIREMENTS_FILE
         sed -i "1i ${PACKAGE_NAME}  @ $BRANCH_URL" $REQUIREMENTS_FILE
+
+        # padre_craft currently pins padre_meddea to PADRESat/main in its own dependency list.
+        # For padre_meddea PR validation, remove padre_craft to avoid resolver conflicts.
+        if [[ "$PACKAGE_NAME" == "padre_meddea" ]]; then
+          sed -i '/^padre_craft[[:space:]]*@/d' $REQUIREMENTS_FILE
+        fi
     
         echo "Updated $REQUIREMENTS_FILE:"
         cat $REQUIREMENTS_FILE

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -1,15 +1,11 @@
 name: Test Lambda Function Locally and Upload Artifacts
 
-on:
-  pull_request:
-    branches:
-      - main
+on: [pull_request_target]
 
 jobs:
   test-and-upload:
     permissions:
         pull-requests: write
-        issues: write
     runs-on: ubuntu-latest
 
     steps:
@@ -139,7 +135,7 @@ jobs:
       run: echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}"
     
     - name: Comment PR
-      if: steps.test-lambda.outputs.test_success == 'true' && github.event_name == 'pull_request'
+      if: steps.test-lambda.outputs.test_success == 'true' && github.event_name == 'pull_request_target'
       uses: andyghc/actions-comment-pull-request@v3
       with:
         message: |

--- a/.github/workflows/test_in_container.yml
+++ b/.github/workflows/test_in_container.yml
@@ -19,6 +19,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Mark repo as safe for git (container workspace)
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install -e '.[test]'
     - name: Run tests
       run: pytest --pyargs padre_meddea --cov padre_meddea
       env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.rst"
 dynamic = ["version"]
 authors = [
   {name = "Steven Christe", email="steven.christe@nasa.gov"},
-  {name = "Andrew Robbertz", email="a.robbertz@gmail.com"},
+  {name = "Andrew Robbertz", email="andrew.l.robbertz@nasa.gov"},
   {name = "Damian Barrous-Dume", email="dbarrous@navteca.com"},
   {name = "Niharika Godbole", email="niharika.godbole@nasa.gov"},
 ]
@@ -37,7 +37,7 @@ dependencies = [
   'matplotlib==3.10.*',
   'swxsoc @ git+https://github.com/swxsoc/swxsoc.git@main',
   'gitpython==3.1.*',
-  'solarnet_metadata @ git+https://github.com/IHDE-Alliance/solarnet_metadata.git@solarnet_metadata_package',
+  'solarnet_metadata',
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   'sunpy==6.*',
   'roentgen==2.2.0',
   'specutils==1.*',
-  'ccsdspy==1.4.*',
+  'ccsdspy',
   'matplotlib==3.10.*',
   'swxsoc @ git+https://github.com/swxsoc/swxsoc.git@main',
   'gitpython==3.1.*',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
   'astropy==6.1.*',
-  'numpy==2.*',
+  'numpy<2.4',
   'sunpy==6.*',
   'roentgen==2.2.0',
   'specutils==1.*',


### PR DESCRIPTION
Since this runs on the Pull Request Target, it will fail here since it's not on the MAIN branch yet. I tested this in my fork with a test PR and things look good! https://github.com/Alrobbertz/padre_meddea/pull/2

- Fix calibration workflow dependency conflict: strip `padre_craft` from Lambda requirements when testing padre_meddea PRs, since `padre_craft` pins padre_meddea to `PADRESat/main` causing a resolver conflict.
- Update Lambda clone URL from `HERMES-SOC` to `swxsoc` org.
- Replace deprecated `thollander/actions-comment-pull-request@v2` (Node 20) with a Node 24-compatible fork; switch trigger to `pull_request_target` so PR comments work from forks.
- Update author email and unpin `solarnet_metadata` from a git URL to allow the PyPI release.